### PR TITLE
fixed customElements.define error

### DIFF
--- a/src/compiler/compile/render_dom/index.ts
+++ b/src/compiler/compile/render_dom/index.ts
@@ -569,7 +569,7 @@ export default function dom(
 
 		if (component.tag != null) {
 			body.push(b`
-				@_customElements.define("${component.tag}", ${name});
+				!@_customElements.get("${component.tag}") && @_customElements.define("${component.tag}", ${name});
 			`);
 		}
 	} else {


### PR DESCRIPTION
When using svelte to create webcomponents components, I found a problem. For example, I created an Icon component first, and then used it for both the Dialog component and the Button component. At this time, an error will be reported saying that the Icon component has been repeatedly defined. To find the cause of the error in the source code of svelte, just modify this code to: ""if (component.tag ! = null) {
body.push(b !@_customElements.get("${component.tag}") && @_customElements.define("${component.tag}", ${name}););

### Before submitting the PR, please make sure you do the following
- [ ] It's really useful if your PR references an issue where it is discussed ahead of time. In many cases, features are absent for a reason. For large changes, please create an RFC: https://github.com/sveltejs/rfcs
- [ ] Prefix your PR title with `[feat]`, `[fix]`, `[chore]`, or `[docs]`.
- [ ] This message body should clearly illustrate what problems it solves.
- [ ] Ideally, include a test that fails without this PR but passes with it.

### Tests
-  [ ] Run the tests with `npm test` and lint the project with `npm run lint`
